### PR TITLE
fix: fix URL from a conda-forge bot update of the version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,13 +7,13 @@ package:
   version: {{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/45/33/4f88384403c3974c82f0296615c6e5f5114ca3d8fd920fa3196e4d619cb0/atlas_schema-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/atlas_schema-{{ version }}.tar.gz
   sha256: e9fe77d3026ac13d1e7c1c139b35704829cccad67f267bb34abbd30fd3eee836
 
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

fb25efd3b56908e9ddc95bedce2a78e2ceb53ba1 was triggered by #9 that updated the version. See discussion in [zulip chat](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/conda-forge.20cannot.20find.20a.20new.20version.20of.20package.20on.20pypi.3F/with/539086442).
